### PR TITLE
Add Defira gateway scaffold w/ correct ABI

### DIFF
--- a/gateway/src/connectors/defira/defira.config.ts
+++ b/gateway/src/connectors/defira/defira.config.ts
@@ -1,0 +1,49 @@
+import { ConfigManagerV2 } from '../../services/config-manager-v2';
+import { AvailableNetworks } from '../../services/config-manager-types';
+export namespace UniswapConfig {
+  export interface NetworkConfig {
+    allowedSlippage: (version: number) => string;
+    gasLimit: (version: number) => number;
+    ttl: (version: number) => number;
+    uniswapV2RouterAddress: (network: string) => string;
+    uniswapV3RouterAddress: (network: string) => string;
+    uniswapV3NftManagerAddress: (network: string) => string;
+    tradingTypes: (network: string) => Array<string>;
+    availableNetworks: Array<AvailableNetworks>;
+  }
+
+  export const config: NetworkConfig = {
+    allowedSlippage: (version: number) =>
+      ConfigManagerV2.getInstance().get(
+        `uniswap.versions.v${version}.allowedSlippage`
+      ),
+    gasLimit: (version: number) =>
+      ConfigManagerV2.getInstance().get(
+        `uniswap.versions.v${version}.gasLimit`
+      ),
+    ttl: (version: number) =>
+      ConfigManagerV2.getInstance().get(`uniswap.versions.v${version}.ttl`),
+    uniswapV2RouterAddress: (network: string) =>
+      ConfigManagerV2.getInstance().get(
+        `uniswap.contractAddresses.${network}.uniswapV2RouterAddress`
+      ),
+    uniswapV3RouterAddress: (network: string) =>
+      ConfigManagerV2.getInstance().get(
+        `uniswap.contractAddresses.${network}.uniswapV3RouterAddress`
+      ),
+    uniswapV3NftManagerAddress: (network: string) =>
+      ConfigManagerV2.getInstance().get(
+        `uniswap.contractAddresses.${network}.uniswapV3NftManagerAddress`
+      ),
+    tradingTypes: (network: string) =>
+      network === 'v2' ? ['EVM_AMM'] : ['EVM_Range_AMM'],
+    availableNetworks: [
+      {
+        chain: 'ethereum',
+        networks: Object.keys(
+          ConfigManagerV2.getInstance().get('uniswap.contractAddresses')
+        ),
+      },
+    ],
+  };
+}

--- a/gateway/src/connectors/defira/defira.config.ts
+++ b/gateway/src/connectors/defira/defira.config.ts
@@ -1,12 +1,14 @@
 import { ConfigManagerV2 } from '../../services/config-manager-v2';
 import { AvailableNetworks } from '../../services/config-manager-types';
-export namespace UniswapConfig {
+export namespace DefiraConfig {
   export interface NetworkConfig {
     allowedSlippage: (version: number) => string;
     gasLimit: (version: number) => number;
     ttl: (version: number) => number;
     uniswapV2RouterAddress: (network: string) => string;
+    // TODO: probably will not need this
     uniswapV3RouterAddress: (network: string) => string;
+    // TODO: probably will not need this
     uniswapV3NftManagerAddress: (network: string) => string;
     tradingTypes: (network: string) => Array<string>;
     availableNetworks: Array<AvailableNetworks>;
@@ -15,25 +17,26 @@ export namespace UniswapConfig {
   export const config: NetworkConfig = {
     allowedSlippage: (version: number) =>
       ConfigManagerV2.getInstance().get(
-        `uniswap.versions.v${version}.allowedSlippage`
+        `defira.versions.v${version}.allowedSlippage`
       ),
     gasLimit: (version: number) =>
-      ConfigManagerV2.getInstance().get(
-        `uniswap.versions.v${version}.gasLimit`
-      ),
+      ConfigManagerV2.getInstance().get(`defira.versions.v${version}.gasLimit`),
     ttl: (version: number) =>
-      ConfigManagerV2.getInstance().get(`uniswap.versions.v${version}.ttl`),
+      ConfigManagerV2.getInstance().get(`defira.versions.v${version}.ttl`),
     uniswapV2RouterAddress: (network: string) =>
       ConfigManagerV2.getInstance().get(
-        `uniswap.contractAddresses.${network}.uniswapV2RouterAddress`
+        `defira.contractAddresses.${network}.uniswapV2RouterAddress`
       ),
+
+    // TODO: probably will not need this
     uniswapV3RouterAddress: (network: string) =>
       ConfigManagerV2.getInstance().get(
-        `uniswap.contractAddresses.${network}.uniswapV3RouterAddress`
+        `defira.contractAddresses.${network}.uniswapV3RouterAddress`
       ),
+    // TODO: probably will not need this
     uniswapV3NftManagerAddress: (network: string) =>
       ConfigManagerV2.getInstance().get(
-        `uniswap.contractAddresses.${network}.uniswapV3NftManagerAddress`
+        `defira.contractAddresses.${network}.uniswapV3NftManagerAddress`
       ),
     tradingTypes: (network: string) =>
       network === 'v2' ? ['EVM_AMM'] : ['EVM_Range_AMM'],
@@ -41,7 +44,7 @@ export namespace UniswapConfig {
       {
         chain: 'ethereum',
         networks: Object.keys(
-          ConfigManagerV2.getInstance().get('uniswap.contractAddresses')
+          ConfigManagerV2.getInstance().get('defira.contractAddresses')
         ),
       },
     ],

--- a/gateway/src/connectors/defira/defira.controllers.ts
+++ b/gateway/src/connectors/defira/defira.controllers.ts
@@ -1,0 +1,366 @@
+import Decimal from 'decimal.js-light';
+import { BigNumber, Wallet } from 'ethers';
+import {
+  HttpException,
+  LOAD_WALLET_ERROR_CODE,
+  LOAD_WALLET_ERROR_MESSAGE,
+  TOKEN_NOT_SUPPORTED_ERROR_CODE,
+  TOKEN_NOT_SUPPORTED_ERROR_MESSAGE,
+  TRADE_FAILED_ERROR_CODE,
+  TRADE_FAILED_ERROR_MESSAGE,
+  SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_CODE,
+  SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_MESSAGE,
+  SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_CODE,
+  SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_MESSAGE,
+  UNKNOWN_ERROR_ERROR_CODE,
+  UNKNOWN_ERROR_MESSAGE,
+} from '../../services/error-handler';
+import { TokenInfo } from '../../services/ethereum-base';
+import { latency, gasCostInEthString } from '../../services/base';
+import {
+  Ethereumish,
+  ExpectedTrade,
+  Uniswapish,
+  Tokenish,
+  Fractionish,
+} from '../../services/common-interfaces';
+import { logger } from '../../services/logger';
+import {
+  EstimateGasResponse,
+  PriceRequest,
+  PriceResponse,
+  TradeRequest,
+  TradeResponse,
+} from '../../amm/amm.requests';
+
+export interface TradeInfo {
+  baseToken: Tokenish;
+  quoteToken: Tokenish;
+  requestAmount: BigNumber;
+  expectedTrade: ExpectedTrade;
+}
+
+export async function getTradeInfo(
+  ethereumish: Ethereumish,
+  uniswapish: Uniswapish,
+  baseAsset: string,
+  quoteAsset: string,
+  baseAmount: Decimal,
+  tradeSide: string,
+  allowedSlippage?: string
+): Promise<TradeInfo> {
+  const baseToken: Tokenish = getFullTokenFromSymbol(
+    ethereumish,
+    uniswapish,
+    baseAsset
+  );
+  const quoteToken: Tokenish = getFullTokenFromSymbol(
+    ethereumish,
+    uniswapish,
+    quoteAsset
+  );
+  const requestAmount: BigNumber = BigNumber.from(
+    baseAmount.toFixed(baseToken.decimals).replace('.', '')
+  );
+
+  let expectedTrade: ExpectedTrade;
+  if (tradeSide === 'BUY') {
+    expectedTrade = await uniswapish.estimateBuyTrade(
+      quoteToken,
+      baseToken,
+      requestAmount,
+      allowedSlippage
+    );
+  } else {
+    expectedTrade = await uniswapish.estimateSellTrade(
+      baseToken,
+      quoteToken,
+      requestAmount,
+      allowedSlippage
+    );
+  }
+
+  return {
+    baseToken,
+    quoteToken,
+    requestAmount,
+    expectedTrade,
+  };
+}
+
+export async function price(
+  ethereumish: Ethereumish,
+  uniswapish: Uniswapish,
+  req: PriceRequest
+): Promise<PriceResponse> {
+  const startTimestamp: number = Date.now();
+  let tradeInfo: TradeInfo;
+  try {
+    tradeInfo = await getTradeInfo(
+      ethereumish,
+      uniswapish,
+      req.base,
+      req.quote,
+      new Decimal(req.amount),
+      req.side,
+      req.allowedSlippage
+    );
+  } catch (e) {
+    if (e instanceof Error) {
+      throw new HttpException(
+        500,
+        TRADE_FAILED_ERROR_MESSAGE + e.message,
+        TRADE_FAILED_ERROR_CODE
+      );
+    } else {
+      throw new HttpException(
+        500,
+        UNKNOWN_ERROR_MESSAGE,
+        UNKNOWN_ERROR_ERROR_CODE
+      );
+    }
+  }
+
+  const trade = tradeInfo.expectedTrade.trade;
+  const expectedAmount = tradeInfo.expectedTrade.expectedAmount;
+
+  const tradePrice =
+    req.side === 'BUY' ? trade.executionPrice.invert() : trade.executionPrice;
+
+  const gasLimit = uniswapish.gasLimit;
+  const gasPrice = ethereumish.gasPrice;
+  return {
+    network: ethereumish.chain,
+    timestamp: startTimestamp,
+    latency: latency(startTimestamp, Date.now()),
+    base: tradeInfo.baseToken.address,
+    quote: tradeInfo.quoteToken.address,
+    amount: new Decimal(req.amount).toFixed(tradeInfo.baseToken.decimals),
+    rawAmount: tradeInfo.requestAmount.toString(),
+    expectedAmount: expectedAmount.toSignificant(8),
+    price: tradePrice.toSignificant(8),
+    gasPrice: gasPrice,
+    gasPriceToken: ethereumish.nativeTokenSymbol,
+    gasLimit: gasLimit,
+    gasCost: gasCostInEthString(gasPrice, gasLimit),
+  };
+}
+
+export async function trade(
+  ethereumish: Ethereumish,
+  uniswapish: Uniswapish,
+  req: TradeRequest
+): Promise<TradeResponse> {
+  const startTimestamp: number = Date.now();
+
+  const { limitPrice, maxFeePerGas, maxPriorityFeePerGas, allowedSlippage } =
+    req;
+
+  let maxFeePerGasBigNumber: BigNumber | undefined;
+  if (maxFeePerGas) {
+    maxFeePerGasBigNumber = BigNumber.from(maxFeePerGas);
+  }
+  let maxPriorityFeePerGasBigNumber: BigNumber | undefined;
+  if (maxPriorityFeePerGas) {
+    maxPriorityFeePerGasBigNumber = BigNumber.from(maxPriorityFeePerGas);
+  }
+
+  let wallet: Wallet;
+  try {
+    wallet = await ethereumish.getWallet(req.address);
+  } catch (err) {
+    logger.error(`Wallet ${req.address} not available.`);
+    throw new HttpException(
+      500,
+      LOAD_WALLET_ERROR_MESSAGE + err,
+      LOAD_WALLET_ERROR_CODE
+    );
+  }
+
+  let tradeInfo: TradeInfo;
+  try {
+    tradeInfo = await getTradeInfo(
+      ethereumish,
+      uniswapish,
+      req.base,
+      req.quote,
+      new Decimal(req.amount),
+      req.side
+    );
+  } catch (e) {
+    if (e instanceof Error) {
+      logger.error(`Could not get trade info. ${e.message}`);
+      throw new HttpException(
+        500,
+        TRADE_FAILED_ERROR_MESSAGE + e.message,
+        TRADE_FAILED_ERROR_CODE
+      );
+    } else {
+      logger.error('Unknown error trying to get trade info.');
+      throw new HttpException(
+        500,
+        UNKNOWN_ERROR_MESSAGE,
+        UNKNOWN_ERROR_ERROR_CODE
+      );
+    }
+  }
+
+  const gasPrice: number = ethereumish.gasPrice;
+  const gasLimit: number = uniswapish.gasLimit;
+
+  if (req.side === 'BUY') {
+    const price: Fractionish =
+      tradeInfo.expectedTrade.trade.executionPrice.invert();
+    if (
+      limitPrice &&
+      new Decimal(price.toFixed(8)).gt(new Decimal(limitPrice))
+    ) {
+      logger.error('Swap price exceeded limit price.');
+      throw new HttpException(
+        500,
+        SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_MESSAGE(
+          price.toFixed(8),
+          limitPrice
+        ),
+        SWAP_PRICE_EXCEEDS_LIMIT_PRICE_ERROR_CODE
+      );
+    }
+
+    const tx = await uniswapish.executeTrade(
+      wallet,
+      tradeInfo.expectedTrade.trade,
+      gasPrice,
+      uniswapish.router,
+      uniswapish.ttl,
+      uniswapish.routerAbi,
+      uniswapish.gasLimit,
+      req.nonce,
+      maxFeePerGasBigNumber,
+      maxPriorityFeePerGasBigNumber,
+      allowedSlippage
+    );
+
+    if (tx.hash) {
+      await ethereumish.txStorage.saveTx(
+        ethereumish.chain,
+        ethereumish.chainId,
+        tx.hash,
+        new Date(),
+        ethereumish.gasPrice
+      );
+    }
+
+    logger.info(
+      `Trade has been executed, txHash is ${tx.hash}, nonce is ${tx.nonce}, gasPrice is ${gasPrice}.`
+    );
+
+    return {
+      network: ethereumish.chain,
+      timestamp: startTimestamp,
+      latency: latency(startTimestamp, Date.now()),
+      base: tradeInfo.baseToken.address,
+      quote: tradeInfo.quoteToken.address,
+      amount: new Decimal(req.amount).toFixed(tradeInfo.baseToken.decimals),
+      rawAmount: tradeInfo.requestAmount.toString(),
+      expectedIn: tradeInfo.expectedTrade.expectedAmount.toSignificant(8),
+      price: price.toSignificant(8),
+      gasPrice: gasPrice,
+      gasPriceToken: ethereumish.nativeTokenSymbol,
+      gasLimit: gasLimit,
+      gasCost: gasCostInEthString(gasPrice, gasLimit),
+      nonce: tx.nonce,
+      txHash: tx.hash,
+    };
+  } else {
+    const price: Fractionish = tradeInfo.expectedTrade.trade.executionPrice;
+    logger.info(
+      `Expected execution price is ${price.toFixed(6)}, ` +
+        `limit price is ${limitPrice}.`
+    );
+    if (
+      limitPrice &&
+      new Decimal(price.toFixed(8)).lt(new Decimal(limitPrice))
+    ) {
+      logger.error('Swap price lower than limit price.');
+      throw new HttpException(
+        500,
+        SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_MESSAGE(
+          price.toFixed(8),
+          limitPrice
+        ),
+        SWAP_PRICE_LOWER_THAN_LIMIT_PRICE_ERROR_CODE
+      );
+    }
+
+    const tx = await uniswapish.executeTrade(
+      wallet,
+      tradeInfo.expectedTrade.trade,
+      gasPrice,
+      uniswapish.router,
+      uniswapish.ttl,
+      uniswapish.routerAbi,
+      uniswapish.gasLimit,
+      req.nonce,
+      maxFeePerGasBigNumber,
+      maxPriorityFeePerGasBigNumber
+    );
+
+    logger.info(
+      `Trade has been executed, txHash is ${tx.hash}, nonce is ${tx.nonce}, gasPrice is ${gasPrice}.`
+    );
+
+    return {
+      network: ethereumish.chain,
+      timestamp: startTimestamp,
+      latency: latency(startTimestamp, Date.now()),
+      base: tradeInfo.baseToken.address,
+      quote: tradeInfo.quoteToken.address,
+      amount: new Decimal(req.amount).toFixed(tradeInfo.baseToken.decimals),
+      rawAmount: tradeInfo.requestAmount.toString(),
+      expectedOut: tradeInfo.expectedTrade.expectedAmount.toSignificant(8),
+      price: price.toSignificant(8),
+      gasPrice: gasPrice,
+      gasPriceToken: ethereumish.nativeTokenSymbol,
+      gasLimit,
+      gasCost: gasCostInEthString(gasPrice, gasLimit),
+      nonce: tx.nonce,
+      txHash: tx.hash,
+    };
+  }
+}
+
+export function getFullTokenFromSymbol(
+  ethereumish: Ethereumish,
+  uniswapish: Uniswapish,
+  tokenSymbol: string
+): Tokenish {
+  const tokenInfo: TokenInfo | undefined =
+    ethereumish.getTokenBySymbol(tokenSymbol);
+  let fullToken: Tokenish | undefined;
+  if (tokenInfo) {
+    fullToken = uniswapish.getTokenByAddress(tokenInfo.address);
+  }
+  if (!fullToken)
+    throw new HttpException(
+      500,
+      TOKEN_NOT_SUPPORTED_ERROR_MESSAGE + tokenSymbol,
+      TOKEN_NOT_SUPPORTED_ERROR_CODE
+    );
+  return fullToken;
+}
+
+export async function estimateGas(
+  ethereumish: Ethereumish,
+  uniswapish: Uniswapish
+): Promise<EstimateGasResponse> {
+  const gasPrice: number = ethereumish.gasPrice;
+  const gasLimit: number = uniswapish.gasLimit;
+  return {
+    network: ethereumish.chain,
+    timestamp: Date.now(),
+    gasPrice,
+    gasPriceToken: ethereumish.nativeTokenSymbol,
+    gasLimit,
+    gasCost: gasCostInEthString(gasPrice, gasLimit),
+  };
+}

--- a/gateway/src/connectors/defira/defira.controllers.ts
+++ b/gateway/src/connectors/defira/defira.controllers.ts
@@ -42,7 +42,7 @@ export interface TradeInfo {
 
 export async function getTradeInfo(
   ethereumish: Ethereumish,
-  uniswapish: Uniswapish,
+  uniswapish: uniswapish,
   baseAsset: string,
   quoteAsset: string,
   baseAmount: Decimal,
@@ -351,7 +351,7 @@ export function getFullTokenFromSymbol(
 
 export async function estimateGas(
   ethereumish: Ethereumish,
-  uniswapish: Uniswapish
+  uniswapish: uniswapish
 ): Promise<EstimateGasResponse> {
   const gasPrice: number = ethereumish.gasPrice;
   const gasLimit: number = uniswapish.gasLimit;

--- a/gateway/src/connectors/defira/defira.ts
+++ b/gateway/src/connectors/defira/defira.ts
@@ -1,12 +1,11 @@
 import {
   InitializationError,
-  UniswapishPriceError,
   SERVICE_UNITIALIZED_ERROR_CODE,
   SERVICE_UNITIALIZED_ERROR_MESSAGE,
 } from '../../services/error-handler';
 import { isFractionString } from '../../services/validators';
-import { UniswapConfig } from './uniswap.config';
-import routerAbi from './uniswap_v2_router_abi.json';
+import { DefiraConfig } from './defira.config';
+import routerAbi from './defira_v2_router_abi.json';
 import {
   Contract,
   ContractInterface,
@@ -28,8 +27,8 @@ import { percentRegexp } from '../../services/config-manager-v2';
 import { Ethereum } from '../../chains/ethereum/ethereum';
 import { ExpectedTrade, Uniswapish } from '../../services/common-interfaces';
 
-export class Uniswap implements Uniswapish {
-  private static _instances: { [name: string]: Uniswap };
+export class defira implements Uniswapish {
+  private static _instances: { [name: string]: defira };
   private ethereum: Ethereum;
   private _chain: string;
   private _router: string;
@@ -42,24 +41,24 @@ export class Uniswap implements Uniswapish {
 
   private constructor(chain: string, network: string) {
     this._chain = chain;
-    const config = UniswapConfig.config;
+    const config = DefiraConfig.config;
     this.ethereum = Ethereum.getInstance(network);
     this.chainId = this.ethereum.chainId;
-    this._ttl = UniswapConfig.config.ttl(2);
+    this._ttl = DefiraConfig.config.ttl(2);
     this._routerAbi = routerAbi.abi;
-    this._gasLimit = UniswapConfig.config.gasLimit(2);
+    this._gasLimit = DefiraConfig.config.gasLimit(2);
     this._router = config.uniswapV2RouterAddress(network);
   }
 
-  public static getInstance(chain: string, network: string): Uniswap {
-    if (Uniswap._instances === undefined) {
-      Uniswap._instances = {};
+  public static getInstance(chain: string, network: string): defira {
+    if (defira._instances === undefined) {
+      defira._instances = {};
     }
-    if (!(chain + network in Uniswap._instances)) {
-      Uniswap._instances[chain + network] = new Uniswap(chain, network);
+    if (!(chain + network in defira._instances)) {
+      defira._instances[chain + network] = new defira(chain, network);
     }
 
-    return Uniswap._instances[chain + network];
+    return defira._instances[chain + network];
   }
 
   /**
@@ -134,7 +133,7 @@ export class Uniswap implements Uniswapish {
       return new Percent(fractionSplit[0], fractionSplit[1]);
     }
 
-    const allowedSlippage = UniswapConfig.config.allowedSlippage(2);
+    const allowedSlippage = DefiraConfig.config.allowedSlippage(2);
     const nd = allowedSlippage.match(percentRegexp);
     if (nd) return new Percent(nd[1], nd[2]);
     throw new Error(
@@ -245,12 +244,12 @@ export class Uniswap implements Uniswapish {
   }
 
   /**
-   * Given a wallet and a Uniswap trade, try to execute it on blockchain.
+   * Given a wallet and a defira trade, try to execute it on blockchain.
    *
    * @param wallet Wallet
    * @param trade Expected trade
    * @param gasPrice Base gas price, for pre-EIP1559 transactions
-   * @param uniswapRouter Router smart contract address
+   * @param defiraRouter Router smart contract address
    * @param ttl How long the swap is valid before expiry, in seconds
    * @param abi Router contract ABI
    * @param gasLimit Gas limit
@@ -262,7 +261,7 @@ export class Uniswap implements Uniswapish {
     wallet: Wallet,
     trade: Trade,
     gasPrice: number,
-    uniswapRouter: string,
+    defiraRouter: string,
     ttl: number,
     abi: ContractInterface,
     gasLimit: number,
@@ -277,7 +276,7 @@ export class Uniswap implements Uniswapish {
       allowedSlippage: this.getAllowedSlippage(allowedSlippage),
     });
 
-    const contract: Contract = new Contract(uniswapRouter, abi, wallet);
+    const contract: Contract = new Contract(defiraRouter, abi, wallet);
     if (nonce === undefined) {
       nonce = await this.ethereum.nonceManager.getNonce(wallet.address);
     }

--- a/gateway/src/connectors/defira/defira.ts
+++ b/gateway/src/connectors/defira/defira.ts
@@ -1,0 +1,306 @@
+import {
+  InitializationError,
+  UniswapishPriceError,
+  SERVICE_UNITIALIZED_ERROR_CODE,
+  SERVICE_UNITIALIZED_ERROR_MESSAGE,
+} from '../../services/error-handler';
+import { isFractionString } from '../../services/validators';
+import { UniswapConfig } from './uniswap.config';
+import routerAbi from './uniswap_v2_router_abi.json';
+import {
+  Contract,
+  ContractInterface,
+  ContractTransaction,
+} from '@ethersproject/contracts';
+import {
+  Fetcher,
+  Percent,
+  Router,
+  Token,
+  TokenAmount,
+  Trade,
+  Pair,
+  SwapParameters,
+} from '@uniswap/sdk';
+import { BigNumber, Transaction, Wallet } from 'ethers';
+import { logger } from '../../services/logger';
+import { percentRegexp } from '../../services/config-manager-v2';
+import { Ethereum } from '../../chains/ethereum/ethereum';
+import { ExpectedTrade, Uniswapish } from '../../services/common-interfaces';
+
+export class Uniswap implements Uniswapish {
+  private static _instances: { [name: string]: Uniswap };
+  private ethereum: Ethereum;
+  private _chain: string;
+  private _router: string;
+  private _routerAbi: ContractInterface;
+  private _gasLimit: number;
+  private _ttl: number;
+  private chainId;
+  private tokenList: Record<string, Token> = {};
+  private _ready: boolean = false;
+
+  private constructor(chain: string, network: string) {
+    this._chain = chain;
+    const config = UniswapConfig.config;
+    this.ethereum = Ethereum.getInstance(network);
+    this.chainId = this.ethereum.chainId;
+    this._ttl = UniswapConfig.config.ttl(2);
+    this._routerAbi = routerAbi.abi;
+    this._gasLimit = UniswapConfig.config.gasLimit(2);
+    this._router = config.uniswapV2RouterAddress(network);
+  }
+
+  public static getInstance(chain: string, network: string): Uniswap {
+    if (Uniswap._instances === undefined) {
+      Uniswap._instances = {};
+    }
+    if (!(chain + network in Uniswap._instances)) {
+      Uniswap._instances[chain + network] = new Uniswap(chain, network);
+    }
+
+    return Uniswap._instances[chain + network];
+  }
+
+  /**
+   * Given a token's address, return the connector's native representation of
+   * the token.
+   *
+   * @param address Token address
+   */
+  public getTokenByAddress(address: string): Token {
+    return this.tokenList[address];
+  }
+
+  public async init() {
+    if (this._chain == 'ethereum' && !this.ethereum.ready())
+      throw new InitializationError(
+        SERVICE_UNITIALIZED_ERROR_MESSAGE('ETH'),
+        SERVICE_UNITIALIZED_ERROR_CODE
+      );
+    for (const token of this.ethereum.storedTokenList) {
+      this.tokenList[token.address] = new Token(
+        this.chainId,
+        token.address,
+        token.decimals,
+        token.symbol,
+        token.name
+      );
+    }
+    this._ready = true;
+  }
+
+  public ready(): boolean {
+    return this._ready;
+  }
+
+  /**
+   * Router address.
+   */
+  public get router(): string {
+    return this._router;
+  }
+
+  /**
+   * Router smart contract ABI.
+   */
+  public get routerAbi(): ContractInterface {
+    return this._routerAbi;
+  }
+
+  /**
+   * Default gas limit for swap transactions.
+   */
+  public get gasLimit(): number {
+    return this._gasLimit;
+  }
+
+  /**
+   * Default time-to-live for swap transactions, in seconds.
+   */
+  public get ttl(): number {
+    return this._ttl;
+  }
+
+  /**
+   * Gets the allowed slippage percent from the optional parameter or the value
+   * in the configuration.
+   *
+   * @param allowedSlippageStr (Optional) should be of the form '1/10'.
+   */
+  public getAllowedSlippage(allowedSlippageStr?: string): Percent {
+    if (allowedSlippageStr != null && isFractionString(allowedSlippageStr)) {
+      const fractionSplit = allowedSlippageStr.split('/');
+      return new Percent(fractionSplit[0], fractionSplit[1]);
+    }
+
+    const allowedSlippage = UniswapConfig.config.allowedSlippage(2);
+    const nd = allowedSlippage.match(percentRegexp);
+    if (nd) return new Percent(nd[1], nd[2]);
+    throw new Error(
+      'Encountered a malformed percent string in the config for ALLOWED_SLIPPAGE.'
+    );
+  }
+
+  /**
+   * Given the amount of `baseToken` to put into a transaction, calculate the
+   * amount of `quoteToken` that can be expected from the transaction.
+   *
+   * This is typically used for calculating token sell prices.
+   *
+   * @param baseToken Token input for the transaction
+   * @param quoteToken Output from the transaction
+   * @param amount Amount of `baseToken` to put into the transaction
+   */
+  async estimateSellTrade(
+    baseToken: Token,
+    quoteToken: Token,
+    amount: BigNumber,
+    allowedSlippage?: string
+  ): Promise<ExpectedTrade> {
+    const nativeTokenAmount: TokenAmount = new TokenAmount(
+      baseToken,
+      amount.toString()
+    );
+    logger.info(
+      `Fetching pair data for ${baseToken.address}-${quoteToken.address}.`
+    );
+
+    const pair: Pair = await Fetcher.fetchPairData(
+      baseToken,
+      quoteToken,
+      this.ethereum.provider
+    );
+    const trades: Trade[] = Trade.bestTradeExactIn(
+      [pair],
+      nativeTokenAmount,
+      quoteToken,
+      { maxHops: 1 }
+    );
+    if (!trades || trades.length === 0) {
+      throw new UniswapishPriceError(
+        `priceSwapIn: no trade pair found for ${baseToken} to ${quoteToken}.`
+      );
+    }
+    logger.info(
+      `Best trade for ${baseToken.address}-${quoteToken.address}: ` +
+        `${trades[0].executionPrice.toFixed(6)}` +
+        `${baseToken.name}.`
+    );
+    const expectedAmount = trades[0].minimumAmountOut(
+      this.getAllowedSlippage(allowedSlippage)
+    );
+    return { trade: trades[0], expectedAmount };
+  }
+
+  /**
+   * Given the amount of `baseToken` desired to acquire from a transaction,
+   * calculate the amount of `quoteToken` needed for the transaction.
+   *
+   * This is typically used for calculating token buy prices.
+   *
+   * @param quoteToken Token input for the transaction
+   * @param baseToken Token output from the transaction
+   * @param amount Amount of `baseToken` desired from the transaction
+   */
+  async estimateBuyTrade(
+    quoteToken: Token,
+    baseToken: Token,
+    amount: BigNumber,
+    allowedSlippage?: string
+  ): Promise<ExpectedTrade> {
+    const nativeTokenAmount: TokenAmount = new TokenAmount(
+      baseToken,
+      amount.toString()
+    );
+    logger.info(
+      `Fetching pair data for ${quoteToken.address}-${baseToken.address}.`
+    );
+    const pair: Pair = await Fetcher.fetchPairData(
+      quoteToken,
+      baseToken,
+      this.ethereum.provider
+    );
+    const trades: Trade[] = Trade.bestTradeExactOut(
+      [pair],
+      quoteToken,
+      nativeTokenAmount,
+      { maxHops: 1 }
+    );
+    if (!trades || trades.length === 0) {
+      throw new UniswapishPriceError(
+        `priceSwapOut: no trade pair found for ${quoteToken.address} to ${baseToken.address}.`
+      );
+    }
+    logger.info(
+      `Best trade for ${quoteToken.address}-${baseToken.address}: ` +
+        `${trades[0].executionPrice.invert().toFixed(6)} ` +
+        `${baseToken.name}.`
+    );
+
+    const expectedAmount = trades[0].maximumAmountIn(
+      this.getAllowedSlippage(allowedSlippage)
+    );
+    return { trade: trades[0], expectedAmount };
+  }
+
+  /**
+   * Given a wallet and a Uniswap trade, try to execute it on blockchain.
+   *
+   * @param wallet Wallet
+   * @param trade Expected trade
+   * @param gasPrice Base gas price, for pre-EIP1559 transactions
+   * @param uniswapRouter Router smart contract address
+   * @param ttl How long the swap is valid before expiry, in seconds
+   * @param abi Router contract ABI
+   * @param gasLimit Gas limit
+   * @param nonce (Optional) EVM transaction nonce
+   * @param maxFeePerGas (Optional) Maximum total fee per gas you want to pay
+   * @param maxPriorityFeePerGas (Optional) Maximum tip per gas you want to pay
+   */
+  async executeTrade(
+    wallet: Wallet,
+    trade: Trade,
+    gasPrice: number,
+    uniswapRouter: string,
+    ttl: number,
+    abi: ContractInterface,
+    gasLimit: number,
+    nonce?: number,
+    maxFeePerGas?: BigNumber,
+    maxPriorityFeePerGas?: BigNumber,
+    allowedSlippage?: string
+  ): Promise<Transaction> {
+    const result: SwapParameters = Router.swapCallParameters(trade, {
+      ttl,
+      recipient: wallet.address,
+      allowedSlippage: this.getAllowedSlippage(allowedSlippage),
+    });
+
+    const contract: Contract = new Contract(uniswapRouter, abi, wallet);
+    if (nonce === undefined) {
+      nonce = await this.ethereum.nonceManager.getNonce(wallet.address);
+    }
+    let tx: ContractTransaction;
+    if (maxFeePerGas !== undefined || maxPriorityFeePerGas !== undefined) {
+      tx = await contract[result.methodName](...result.args, {
+        gasLimit: gasLimit.toFixed(0),
+        value: result.value,
+        nonce: nonce,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+      });
+    } else {
+      tx = await contract[result.methodName](...result.args, {
+        gasPrice: (gasPrice * 1e9).toFixed(0),
+        gasLimit: gasLimit.toFixed(0),
+        value: result.value,
+        nonce: nonce,
+      });
+    }
+
+    logger.info(tx);
+    await this.ethereum.nonceManager.commitNonce(wallet.address, nonce);
+    return tx;
+  }
+}

--- a/gateway/src/connectors/defira/defira.v3.helper.ts
+++ b/gateway/src/connectors/defira/defira.v3.helper.ts
@@ -1,0 +1,355 @@
+import { logger } from '../../services/logger';
+import { UniswapConfig } from './uniswap.config';
+import { Contract, ContractInterface } from '@ethersproject/contracts';
+import { Token, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core';
+import * as uniV3 from '@uniswap/v3-sdk';
+import { providers, Wallet, Signer, utils } from 'ethers';
+import { percentRegexp } from '../../services/config-manager-v2';
+import { Ethereum } from '../../chains/ethereum/ethereum';
+import {
+  PoolState,
+  RawPosition,
+  AddLiquidityData,
+  IncreaseLiquidityData,
+  ReduceLiquidityData,
+} from './uniswap.v3.interfaces';
+import * as math from 'mathjs';
+
+export class UniswapV3Helper {
+  protected ethereum: Ethereum;
+  private _router: string;
+  private _nftManager: string;
+  private _ttl: number;
+  private _routerAbi: ContractInterface;
+  private _nftAbi: ContractInterface;
+  private _poolAbi: ContractInterface;
+
+  constructor(network: string) {
+    this.ethereum = Ethereum.getInstance(network);
+    this._router = UniswapConfig.config.uniswapV3RouterAddress(network);
+    this._nftManager = UniswapConfig.config.uniswapV3NftManagerAddress(network);
+    this._ttl = UniswapConfig.config.ttl(3);
+    this._routerAbi =
+      require('@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json').abi;
+    this._nftAbi =
+      require('@uniswap/v3-periphery/artifacts/contracts/NonfungiblePositionManager.sol/NonfungiblePositionManager.json').abi;
+    this._poolAbi =
+      require('@uniswap/v3-core/artifacts/contracts/UniswapV3Pool.sol/UniswapV3Pool.json').abi;
+  }
+
+  public get router(): string {
+    return this._router;
+  }
+
+  public get nftManager(): string {
+    return this._nftManager;
+  }
+
+  public get ttl(): number {
+    return parseInt(String(Date.now() / 1000)) + this._ttl;
+  }
+
+  public get routerAbi(): ContractInterface {
+    return this._routerAbi;
+  }
+
+  public get nftAbi(): ContractInterface {
+    return this._nftAbi;
+  }
+
+  public get poolAbi(): ContractInterface {
+    return this._poolAbi;
+  }
+
+  public getTokenByAddress(address: string): Token {
+    const tokenFilter = this.ethereum.storedTokenList.filter(
+      (t) => t.address === address
+    );
+    if (tokenFilter.length === 0) {
+      throw `Cannot find token info for token address ${address}.`;
+    }
+    return new Token(
+      this.ethereum.chainId,
+      tokenFilter[0].address,
+      tokenFilter[0].decimals,
+      tokenFilter[0].symbol,
+      tokenFilter[0].name
+    );
+  }
+
+  getPercentage(rawPercent: number | string): Percent {
+    const slippage = math.fraction(rawPercent) as math.Fraction;
+    return new Percent(slippage.n, slippage.d * 100);
+  }
+
+  getSlippagePercentage(): Percent {
+    const allowedSlippage = UniswapConfig.config.allowedSlippage(3);
+    const nd = allowedSlippage.match(percentRegexp);
+    if (nd) return new Percent(nd[1], nd[2]);
+    throw new Error(
+      'Encountered a malformed percent string in the config for ALLOWED_SLIPPAGE.'
+    );
+  }
+
+  getContract(contract: string, wallet: Wallet | Signer): Contract {
+    if (contract === 'router') {
+      return new Contract(this.router, this.routerAbi, wallet);
+    } else {
+      return new Contract(this.nftManager, this.nftAbi, wallet);
+    }
+  }
+
+  getPoolContract(
+    pool: string,
+    wallet: providers.StaticJsonRpcProvider | Signer
+  ): Contract {
+    return new Contract(pool, this.routerAbi, wallet);
+  }
+
+  async getPoolState(
+    poolAddress: string,
+    fee: uniV3.FeeAmount,
+    wallet: providers.StaticJsonRpcProvider | Signer
+  ): Promise<PoolState> {
+    const poolContract = this.getPoolContract(poolAddress, wallet);
+    const minTick = uniV3.nearestUsableTick(
+      uniV3.TickMath.MIN_TICK,
+      uniV3.TICK_SPACINGS[fee]
+    );
+    const maxTick = uniV3.nearestUsableTick(
+      uniV3.TickMath.MAX_TICK,
+      uniV3.TICK_SPACINGS[fee]
+    );
+    const poolDataReq = await Promise.allSettled([
+      poolContract.liquidity(),
+      poolContract.slot0(),
+      poolContract.ticks(minTick),
+      poolContract.ticks(maxTick),
+    ]);
+
+    const rejected = poolDataReq.filter(
+      (r) => r.status === 'rejected'
+    ) as PromiseRejectedResult[];
+
+    if (rejected.length > 0) throw 'Unable to fetch pool state';
+
+    const poolData = (
+      poolDataReq.filter(
+        (r) => r.status === 'fulfilled'
+      ) as PromiseFulfilledResult<any>[]
+    ).map((r) => r.value);
+
+    return {
+      liquidity: poolData[0],
+      sqrtPriceX96: poolData[1][0],
+      tick: poolData[1][1],
+      observationIndex: poolData[1][2],
+      observationCardinality: poolData[1][3],
+      observationCardinalityNext: poolData[1][4],
+      feeProtocol: poolData[1][5],
+      unlocked: poolData[1][6],
+      fee: fee,
+      tickProvider: [
+        {
+          index: minTick,
+          liquidityNet: poolData[2][1],
+          liquidityGross: poolData[2][0],
+        },
+        {
+          index: maxTick,
+          liquidityNet: poolData[3][1],
+          liquidityGross: poolData[3][0],
+        },
+      ],
+    };
+  }
+
+  async getPairs(firstToken: Token, secondToken: Token): Promise<uniV3.Pool[]> {
+    const poolDataRequests = [];
+    const pools: uniV3.Pool[] = [];
+    try {
+      for (const tier of Object.values(uniV3.FeeAmount)) {
+        if (typeof tier !== 'string') {
+          const poolAddress = uniV3.Pool.getAddress(
+            firstToken,
+            secondToken,
+            tier
+          );
+          poolDataRequests.push(
+            this.getPoolState(poolAddress, tier, this.ethereum.provider)
+          );
+        }
+      }
+      const poolDataRaw = await Promise.allSettled(poolDataRequests);
+      const poolDataRes = (
+        poolDataRaw.filter(
+          (r) => r.status === 'fulfilled'
+        ) as PromiseFulfilledResult<any>[]
+      ).map((r) => r.value);
+
+      for (const poolData of poolDataRes) {
+        pools.push(
+          new uniV3.Pool(
+            firstToken,
+            secondToken,
+            poolData.fee,
+            poolData.sqrtPriceX96.toString(),
+            poolData.liquidity.toString(),
+            poolData.tick,
+            poolData.tickProvider
+          )
+        );
+      }
+    } catch (err) {
+      logger.error(err);
+    }
+    return pools;
+  }
+
+  async getRawPosition(wallet: Wallet, tokenId: number): Promise<RawPosition> {
+    const contract = this.getContract('nft', wallet);
+    const requests = [contract.positions(tokenId)];
+    const positionInfoReq = await Promise.allSettled(requests);
+    const rejected = positionInfoReq.filter(
+      (r) => r.status === 'rejected'
+    ) as PromiseRejectedResult[];
+    if (rejected.length > 0) throw 'Unable to fetch position';
+    const positionInfo = (
+      positionInfoReq.filter(
+        (r) => r.status === 'fulfilled'
+      ) as PromiseFulfilledResult<any>[]
+    ).map((r) => r.value);
+    return positionInfo[0];
+  }
+
+  getReduceLiquidityData(
+    percent: number,
+    tokenId: number,
+    token0: Token,
+    token1: Token,
+    wallet: Wallet
+  ): ReduceLiquidityData {
+    return {
+      tokenId: tokenId,
+      liquidityPercentage: this.getPercentage(percent),
+      slippageTolerance: this.getSlippagePercentage(),
+      deadline: this.ttl,
+      burnToken: false,
+      collectOptions: {
+        expectedCurrencyOwed0: CurrencyAmount.fromRawAmount(token0, '0'),
+        expectedCurrencyOwed1: CurrencyAmount.fromRawAmount(token1, '0'),
+        recipient: wallet.address,
+      },
+    };
+  }
+
+  getAddLiquidityData(
+    wallet: Wallet,
+    tokenId: number
+  ): AddLiquidityData | IncreaseLiquidityData {
+    let extraData;
+    const commonData = {
+      slippageTolerance: this.getSlippagePercentage(),
+      deadline: this.ttl,
+    };
+    if (tokenId == 0) {
+      extraData = { recipient: wallet.address, createPool: true };
+    } else {
+      extraData = { tokenId: tokenId };
+    }
+    return { ...commonData, ...extraData };
+  }
+
+  async addPositionHelper(
+    wallet: Wallet,
+    tokenIn: Token,
+    tokenOut: Token,
+    amount0: string,
+    amount1: string,
+    fee: uniV3.FeeAmount,
+    lowerPrice: number,
+    upperPrice: number,
+    tokenId: number = 0
+  ): Promise<uniV3.MethodParameters> {
+    const lowerPriceInFraction = math.fraction(lowerPrice) as math.Fraction;
+    const upperPriceInFraction = math.fraction(upperPrice) as math.Fraction;
+    const poolAddress = uniV3.Pool.getAddress(tokenIn, tokenOut, fee);
+    const poolData = await this.getPoolState(poolAddress, fee, wallet);
+    const position = uniV3.Position.fromAmounts({
+      pool: new uniV3.Pool(
+        tokenIn,
+        tokenOut,
+        poolData.fee,
+        poolData.sqrtPriceX96.toString(),
+        poolData.liquidity.toString(),
+        poolData.tick
+      ),
+      tickLower: uniV3.nearestUsableTick(
+        uniV3.priceToClosestTick(
+          new Price(
+            tokenIn,
+            tokenOut,
+            lowerPriceInFraction.d,
+            lowerPriceInFraction.n
+          )
+        ),
+        uniV3.TICK_SPACINGS[fee]
+      ),
+      tickUpper: uniV3.nearestUsableTick(
+        uniV3.priceToClosestTick(
+          new Price(
+            tokenIn,
+            tokenOut,
+            upperPriceInFraction.d,
+            upperPriceInFraction.n
+          )
+        ),
+        uniV3.TICK_SPACINGS[fee]
+      ),
+      amount0: utils.parseUnits(amount0, tokenIn.decimals).toString(),
+      amount1: utils.parseUnits(amount1, tokenOut.decimals).toString(),
+      useFullPrecision: true,
+    });
+    return uniV3.NonfungiblePositionManager.addCallParameters(
+      position,
+      this.getAddLiquidityData(wallet, tokenId)
+    );
+  }
+
+  async reducePositionHelper(
+    wallet: Wallet,
+    tokenId: number,
+    decreasePercent: number
+  ): Promise<uniV3.MethodParameters> {
+    // Reduce position and burn
+    const positionData = await this.getRawPosition(wallet, tokenId);
+    const tokenIn = this.getTokenByAddress(positionData.token0);
+    const tokenOut = this.getTokenByAddress(positionData.token1);
+    const fee = positionData.fee;
+    const poolAddress = uniV3.Pool.getAddress(tokenIn, tokenOut, fee);
+    const poolData = await this.getPoolState(poolAddress, fee, wallet);
+    const position = new uniV3.Position({
+      pool: new uniV3.Pool(
+        tokenIn,
+        tokenOut,
+        poolData.fee,
+        poolData.sqrtPriceX96.toString(),
+        poolData.liquidity.toString(),
+        poolData.tick
+      ),
+      tickLower: positionData.tickLower,
+      tickUpper: positionData.tickUpper,
+      liquidity: positionData.liquidity,
+    });
+    return uniV3.NonfungiblePositionManager.removeCallParameters(
+      position,
+      this.getReduceLiquidityData(
+        decreasePercent,
+        tokenId,
+        tokenIn,
+        tokenOut,
+        wallet
+      )
+    );
+  }
+}

--- a/gateway/src/connectors/defira/defira.v3.helper.ts
+++ b/gateway/src/connectors/defira/defira.v3.helper.ts
@@ -1,5 +1,6 @@
+// TODO: probably won't need this file
 import { logger } from '../../services/logger';
-import { UniswapConfig } from './uniswap.config';
+import { DefiraConfig } from './defira.config';
 import { Contract, ContractInterface } from '@ethersproject/contracts';
 import { Token, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core';
 import * as uniV3 from '@uniswap/v3-sdk';
@@ -12,10 +13,10 @@ import {
   AddLiquidityData,
   IncreaseLiquidityData,
   ReduceLiquidityData,
-} from './uniswap.v3.interfaces';
+} from './defira.v3.interfaces';
 import * as math from 'mathjs';
 
-export class UniswapV3Helper {
+export class DefiraV3Helper {
   protected ethereum: Ethereum;
   private _router: string;
   private _nftManager: string;
@@ -26,9 +27,9 @@ export class UniswapV3Helper {
 
   constructor(network: string) {
     this.ethereum = Ethereum.getInstance(network);
-    this._router = UniswapConfig.config.uniswapV3RouterAddress(network);
-    this._nftManager = UniswapConfig.config.uniswapV3NftManagerAddress(network);
-    this._ttl = UniswapConfig.config.ttl(3);
+    this._router = DefiraConfig.config.uniswapV3RouterAddress(network);
+    this._nftManager = DefiraConfig.config.uniswapV3NftManagerAddress(network);
+    this._ttl = DefiraConfig.config.ttl(3);
     this._routerAbi =
       require('@uniswap/v3-periphery/artifacts/contracts/SwapRouter.sol/SwapRouter.json').abi;
     this._nftAbi =
@@ -83,7 +84,7 @@ export class UniswapV3Helper {
   }
 
   getSlippagePercentage(): Percent {
-    const allowedSlippage = UniswapConfig.config.allowedSlippage(3);
+    const allowedSlippage = DefiraConfig.config.allowedSlippage(3);
     const nd = allowedSlippage.match(percentRegexp);
     if (nd) return new Percent(nd[1], nd[2]);
     throw new Error(

--- a/gateway/src/connectors/defira/defira.v3.helper.ts
+++ b/gateway/src/connectors/defira/defira.v3.helper.ts
@@ -6,7 +6,7 @@ import { Token, CurrencyAmount, Percent, Price } from '@uniswap/sdk-core';
 import * as uniV3 from '@uniswap/v3-sdk';
 import { providers, Wallet, Signer, utils } from 'ethers';
 import { percentRegexp } from '../../services/config-manager-v2';
-import { Ethereum } from '../../chains/ethereum/ethereum';
+import { Harmony } from '../../chains/harmony/harmony';
 import {
   PoolState,
   RawPosition,
@@ -17,7 +17,7 @@ import {
 import * as math from 'mathjs';
 
 export class DefiraV3Helper {
-  protected ethereum: Ethereum;
+  protected harmony: Harmony;
   private _router: string;
   private _nftManager: string;
   private _ttl: number;
@@ -26,7 +26,7 @@ export class DefiraV3Helper {
   private _poolAbi: ContractInterface;
 
   constructor(network: string) {
-    this.ethereum = Ethereum.getInstance(network);
+    this.harmony = Harmony.getInstance(network);
     this._router = DefiraConfig.config.uniswapV3RouterAddress(network);
     this._nftManager = DefiraConfig.config.uniswapV3NftManagerAddress(network);
     this._ttl = DefiraConfig.config.ttl(3);
@@ -63,14 +63,14 @@ export class DefiraV3Helper {
   }
 
   public getTokenByAddress(address: string): Token {
-    const tokenFilter = this.ethereum.storedTokenList.filter(
+    const tokenFilter = this.harmony.storedTokenList.filter(
       (t) => t.address === address
     );
     if (tokenFilter.length === 0) {
       throw `Cannot find token info for token address ${address}.`;
     }
     return new Token(
-      this.ethereum.chainId,
+      this.harmony.chainId,
       tokenFilter[0].address,
       tokenFilter[0].decimals,
       tokenFilter[0].symbol,
@@ -177,7 +177,7 @@ export class DefiraV3Helper {
             tier
           );
           poolDataRequests.push(
-            this.getPoolState(poolAddress, tier, this.ethereum.provider)
+            this.getPoolState(poolAddress, tier, this.harmony.provider)
           );
         }
       }

--- a/gateway/src/connectors/defira/defira.v3.interfaces.ts
+++ b/gateway/src/connectors/defira/defira.v3.interfaces.ts
@@ -1,0 +1,61 @@
+import { CurrencyAmount, Percent, Token } from '@uniswap/sdk-core';
+import * as uniV3 from '@uniswap/v3-sdk';
+import { BigNumber } from 'ethers';
+
+export interface PoolState {
+  liquidity: BigNumber;
+  sqrtPriceX96: BigNumber;
+  tick: number;
+  observationIndex: BigNumber;
+  observationCardinality: BigNumber;
+  observationCardinalityNext: BigNumber;
+  feeProtocol: BigNumber;
+  unlocked: boolean;
+  fee: uniV3.FeeAmount;
+  tickProvider: {
+    index: number;
+    liquidityNet: BigNumber;
+    liquidityGross: BigNumber;
+  }[];
+}
+
+export interface RawPosition {
+  nonce: number;
+  operator: string;
+  token0: string;
+  token1: string;
+  fee: number;
+  tickLower: number;
+  tickUpper: number;
+  liquidity: number;
+  feeGrowthInside0LastX128: BigNumber;
+  feeGrowthInside1LastX128: BigNumber;
+  tokensOwed0: BigNumber;
+  tokensOwed1: BigNumber;
+}
+
+export interface AddLiquidityData {
+  recipient: string;
+  createPool: boolean;
+  slippageTolerance: Percent;
+  deadline: number;
+}
+
+export interface IncreaseLiquidityData {
+  tokenId: number;
+  slippageTolerance: Percent;
+  deadline: number;
+}
+
+export interface ReduceLiquidityData {
+  tokenId: number;
+  liquidityPercentage: Percent;
+  slippageTolerance: Percent;
+  deadline: number;
+  burnToken: boolean;
+  collectOptions: {
+    expectedCurrencyOwed0: CurrencyAmount<Token>;
+    expectedCurrencyOwed1: CurrencyAmount<Token>;
+    recipient: string;
+  };
+}

--- a/gateway/src/connectors/defira/defira.v3.interfaces.ts
+++ b/gateway/src/connectors/defira/defira.v3.interfaces.ts
@@ -1,3 +1,4 @@
+// TODO: probably won't need this file
 import { CurrencyAmount, Percent, Token } from '@uniswap/sdk-core';
 import * as uniV3 from '@uniswap/v3-sdk';
 import { BigNumber } from 'ethers';

--- a/gateway/src/connectors/defira/defira.v3.ts
+++ b/gateway/src/connectors/defira/defira.v3.ts
@@ -1,0 +1,399 @@
+import {
+  InitializationError,
+  UniswapishPriceError,
+  SERVICE_UNITIALIZED_ERROR_CODE,
+  SERVICE_UNITIALIZED_ERROR_MESSAGE,
+} from '../../services/error-handler';
+import { logger } from '../../services/logger';
+import { UniswapConfig } from './uniswap.config';
+import { Contract, ContractInterface } from '@ethersproject/contracts';
+import { Token, CurrencyAmount, TradeType } from '@uniswap/sdk-core';
+import * as uniV3 from '@uniswap/v3-sdk';
+import { BigNumber, Transaction, Wallet, utils } from 'ethers';
+import { ExpectedTrade, Uniswapish } from '../../services/common-interfaces';
+import { UniswapV3Helper } from './uniswap.v3.helper';
+
+const MaxUint128 = BigNumber.from(2).pow(128).sub(1);
+
+export type Overrides = {
+  gasLimit: string;
+  gasPrice?: string;
+  value?: string;
+  nonce?: number;
+  maxFeePerGas?: BigNumber;
+  maxPriorityFeePerGas?: BigNumber;
+};
+
+type SellTrade = uniV3.Trade<Token, Token, TradeType.EXACT_INPUT>;
+type BuyTrade = uniV3.Trade<Token, Token, TradeType.EXACT_OUTPUT>;
+
+export class UniswapV3 extends UniswapV3Helper implements Uniswapish {
+  private static _instances: { [name: string]: UniswapV3 };
+  private _chain: string;
+  private _gasLimit: number;
+  private _ready: boolean = false;
+
+  private constructor(chain: string, network: string) {
+    super(network);
+    this._chain = chain;
+    this._gasLimit = UniswapConfig.config.gasLimit(3);
+  }
+
+  public static getInstance(chain: string, network: string): UniswapV3 {
+    if (UniswapV3._instances === undefined) {
+      UniswapV3._instances = {};
+    }
+    if (!(chain + network in UniswapV3._instances)) {
+      UniswapV3._instances[chain + network] = new UniswapV3(chain, network);
+    }
+
+    return UniswapV3._instances[chain + network];
+  }
+
+  public async init() {
+    if (this._chain == 'ethereum' && !this.ethereum.ready())
+      throw new InitializationError(
+        SERVICE_UNITIALIZED_ERROR_MESSAGE('ETH'),
+        SERVICE_UNITIALIZED_ERROR_CODE
+      );
+    this._ready = true;
+  }
+
+  public ready(): boolean {
+    return this._ready;
+  }
+
+  /**
+   * Default gas limit for swap transactions.
+   */
+  public get gasLimit(): number {
+    return this._gasLimit;
+  }
+
+  /**
+   * Given the amount of `baseToken` to put into a transaction, calculate the
+   * amount of `quoteToken` that can be expected from the transaction.
+   *
+   * This is typically used for calculating token sell prices.
+   *
+   * @param baseToken Token input for the transaction
+   * @param quoteToken Output from the transaction
+   * @param amount Amount of `baseToken` to put into the transaction
+   */
+  async estimateSellTrade(
+    baseToken: Token,
+    quoteToken: Token,
+    amount: BigNumber
+  ): Promise<ExpectedTrade> {
+    const tokenAmountIn: CurrencyAmount<Token> = CurrencyAmount.fromRawAmount(
+      baseToken,
+      amount.toString()
+    );
+    const pools: uniV3.Pool[] = await this.getPairs(baseToken, quoteToken);
+    const trades: SellTrade[] = await uniV3.Trade.bestTradeExactIn(
+      pools,
+      tokenAmountIn,
+      quoteToken,
+      { maxHops: 1 }
+    );
+    if (!trades || trades.length === 0) {
+      throw new UniswapishPriceError(
+        `priceSwapOut: no trade pair found for ${baseToken.address} to ${quoteToken.address}.`
+      );
+    }
+    const trade: SellTrade = trades[0];
+    const expectedAmount: CurrencyAmount<Token> = trade.minimumAmountOut(
+      this.getSlippagePercentage()
+    );
+    return { trade, expectedAmount };
+  }
+
+  /**
+   * Given the amount of `baseToken` desired to acquire from a transaction,
+   * calculate the amount of `quoteToken` needed for the transaction.
+   *
+   * This is typically used for calculating token buy prices.
+   *
+   * @param quoteToken Token input for the transaction
+   * @param baseToken Token output from the transaction
+   * @param amount Amount of `baseToken` desired from the transaction
+   */
+  async estimateBuyTrade(
+    quoteToken: Token,
+    baseToken: Token,
+    amount: BigNumber
+  ): Promise<ExpectedTrade> {
+    const tokenAmountOut: CurrencyAmount<Token> = CurrencyAmount.fromRawAmount(
+      baseToken,
+      amount.toString()
+    );
+    const pools: uniV3.Pool[] = await this.getPairs(quoteToken, baseToken);
+    const trades: BuyTrade[] = await uniV3.Trade.bestTradeExactOut(
+      pools,
+      quoteToken,
+      tokenAmountOut,
+      { maxHops: 1 }
+    );
+    if (!trades || trades.length === 0) {
+      throw new UniswapishPriceError(
+        `priceSwapOut: no trade pair found for ${quoteToken.address} to ${baseToken.address}.`
+      );
+    }
+    const trade: BuyTrade = trades[0];
+    const expectedAmount: CurrencyAmount<Token> = trade.maximumAmountIn(
+      this.getSlippagePercentage()
+    );
+    return { trade, expectedAmount };
+  }
+
+  /**
+   * Given a wallet and a Uniswap-ish trade, try to execute it on blockchain.
+   *
+   * @param wallet Wallet
+   * @param trade Expected trade
+   * @param gasPrice Base gas price, for pre-EIP1559 transactions
+   * @param uniswapRouter Router smart contract address
+   * @param ttl How long the swap is valid before expiry, in seconds
+   * @param abi Router contract ABI
+   * @param gasLimit Gas limit
+   * @param nonce (Optional) EVM transaction nonce
+   * @param maxFeePerGas (Optional) Maximum total fee per gas you want to pay
+   * @param maxPriorityFeePerGas (Optional) Maximum tip per gas you want to pay
+   */
+  async executeTrade(
+    wallet: Wallet,
+    trade: uniV3.Trade<Token, Token, TradeType>,
+    gasPrice: number,
+    uniswapRouter: string,
+    ttl: number,
+    abi: ContractInterface,
+    gasLimit: number,
+    nonce?: number,
+    maxFeePerGas?: BigNumber,
+    maxPriorityFeePerGas?: BigNumber
+  ): Promise<Transaction> {
+    const { calldata, value } = uniV3.SwapRouter.swapCallParameters(trade, {
+      deadline: ttl,
+      recipient: wallet.address,
+      slippageTolerance: this.getSlippagePercentage(),
+    });
+    const contract: Contract = new Contract(uniswapRouter, abi, wallet);
+
+    const tx: Transaction = await contract.multicall(
+      [calldata],
+      this.generateOverrides(
+        gasLimit,
+        gasPrice,
+        nonce,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        value
+      )
+    );
+    logger.info(`Uniswap V3 swap Tx Hash: ${tx.hash}`);
+    return tx;
+  }
+
+  async getPosition(
+    wallet: Wallet,
+    tokenId: number
+  ): Promise<{
+    token0: string | undefined;
+    token1: string | undefined;
+    fee: string | undefined;
+    lowerPrice: string;
+    upperPrice: string;
+    amount0: string;
+    amount1: string;
+    unclaimedToken0: string;
+    unclaimedToken1: string;
+  }> {
+    const contract = this.getContract('nft', wallet);
+    const requests = [
+      contract.positions(tokenId),
+      this.collectFees(wallet, tokenId, true),
+    ];
+    const positionInfoReq = await Promise.allSettled(requests);
+    const rejected = positionInfoReq.filter(
+      (r) => r.status === 'rejected'
+    ) as PromiseRejectedResult[];
+    if (rejected.length > 0) throw 'Unable to fetch position';
+    const positionInfo = (
+      positionInfoReq.filter(
+        (r) => r.status === 'fulfilled'
+      ) as PromiseFulfilledResult<any>[]
+    ).map((r) => r.value);
+    const position = positionInfo[0];
+    const feeInfo = positionInfo[1];
+    const token0 = this.getTokenByAddress(position.token0);
+    const token1 = this.getTokenByAddress(position.token1);
+    const fee = position.fee;
+    const poolAddress = uniV3.Pool.getAddress(token0, token1, fee);
+    const poolData = await this.getPoolState(poolAddress, fee, wallet);
+    const positionInst = new uniV3.Position({
+      pool: new uniV3.Pool(
+        token0,
+        token1,
+        poolData.fee,
+        poolData.sqrtPriceX96.toString(),
+        poolData.liquidity.toString(),
+        poolData.tick
+      ),
+      tickLower: position.tickLower,
+      tickUpper: position.tickUpper,
+      liquidity: position.liquidity,
+    });
+    return {
+      token0: token0.symbol,
+      token1: token1.symbol,
+      fee: Object.keys(uniV3.FeeAmount).find(
+        (key) => uniV3.FeeAmount[Number(key)] === position.fee
+      ),
+      lowerPrice: positionInst.token0PriceLower.toFixed(8),
+      upperPrice: positionInst.token0PriceUpper.toFixed(8),
+      amount0: positionInst.amount0.toFixed(8),
+      amount1: positionInst.amount1.toFixed(8),
+      unclaimedToken0: utils.formatUnits(
+        feeInfo.amount0.toString(),
+        token0.decimals
+      ),
+      unclaimedToken1: utils.formatUnits(
+        feeInfo.amount1.toString(),
+        token1.decimals
+      ),
+    };
+  }
+
+  async addPosition(
+    wallet: Wallet,
+    tokenIn: Token,
+    tokenOut: Token,
+    amount0: string,
+    amount1: string,
+    fee: uniV3.FeeAmount,
+    lowerPrice: number,
+    upperPrice: number,
+    tokenId: number = 0,
+    gasLimit: number,
+    gasPrice: number,
+    nonce?: number,
+    maxFeePerGas?: BigNumber,
+    maxPriorityFeePerGas?: BigNumber
+  ): Promise<Transaction> {
+    const { calldata, value } = await this.addPositionHelper(
+      wallet,
+      tokenIn,
+      tokenOut,
+      amount0,
+      amount1,
+      fee,
+      lowerPrice,
+      upperPrice,
+      tokenId
+    );
+    const nftContract = this.getContract('nft', wallet);
+    const tx = await nftContract.multicall(
+      [calldata],
+      this.generateOverrides(
+        gasLimit,
+        gasPrice,
+        nonce,
+        maxFeePerGas,
+        maxPriorityFeePerGas,
+        value
+      )
+    );
+    logger.info(`Uniswap V3 Add position Tx Hash: ${tx.hash}`);
+    return tx;
+  }
+
+  async reducePosition(
+    wallet: Wallet,
+    tokenId: number,
+    decreasePercent: number = 100,
+    getFee: boolean = false,
+    gasLimit: number,
+    gasPrice: number,
+    nonce?: number,
+    maxFeePerGas?: BigNumber,
+    maxPriorityFeePerGas?: BigNumber
+  ): Promise<BigNumber | Transaction> {
+    // Reduce position and burn
+    const contract = this.getContract('nft', wallet);
+    const { calldata, value } = await this.reducePositionHelper(
+      wallet,
+      tokenId,
+      decreasePercent
+    );
+    if (getFee) {
+      return await contract.estimateGas.multicall([calldata], {
+        value: value,
+      });
+    } else {
+      const tx = await contract.multicall(
+        [calldata],
+        this.generateOverrides(
+          gasLimit,
+          gasPrice,
+          nonce,
+          maxFeePerGas,
+          maxPriorityFeePerGas,
+          value
+        )
+      );
+      logger.info(`Uniswap V3 Remove position Tx Hash: ${tx.hash}`);
+      return tx;
+    }
+  }
+
+  async collectFees(
+    wallet: Wallet,
+    tokenId: number,
+    isStatic: boolean = false,
+    gasLimit: number = this.gasLimit,
+    gasPrice: number = 0,
+    nonce?: number,
+    maxFeePerGas?: BigNumber,
+    maxPriorityFeePerGas?: BigNumber
+  ): Promise<Transaction | { amount0: BigNumber; amount1: BigNumber }> {
+    const contract = this.getContract('nft', wallet);
+    const collectData = {
+      tokenId: tokenId,
+      recipient: wallet.address,
+      amount0Max: MaxUint128,
+      amount1Max: MaxUint128,
+    };
+    return isStatic
+      ? await contract.callStatic.collect(collectData)
+      : await contract.collect(
+          collectData,
+          this.generateOverrides(
+            gasLimit,
+            gasPrice,
+            nonce,
+            maxFeePerGas,
+            maxPriorityFeePerGas
+          )
+        );
+  }
+
+  generateOverrides(
+    gasLimit: number,
+    gasPrice: number,
+    nonce?: number,
+    maxFeePerGas?: BigNumber,
+    maxPriorityFeePerGas?: BigNumber,
+    value?: string
+  ): Overrides {
+    const overrides: Overrides = { gasLimit: gasLimit.toFixed(0) };
+    if (maxFeePerGas && maxPriorityFeePerGas) {
+      overrides.maxFeePerGas = maxFeePerGas;
+      overrides.maxPriorityFeePerGas = maxPriorityFeePerGas;
+    } else {
+      overrides.gasPrice = (gasPrice * 1e9).toFixed(0);
+    }
+    if (nonce) overrides.nonce = nonce;
+    if (value) overrides.value = value;
+    return overrides;
+  }
+}

--- a/gateway/src/connectors/defira/defira.v3.ts
+++ b/gateway/src/connectors/defira/defira.v3.ts
@@ -1,3 +1,4 @@
+// TODO: probably won't need this file
 import {
   InitializationError,
   UniswapishPriceError,
@@ -5,13 +6,13 @@ import {
   SERVICE_UNITIALIZED_ERROR_MESSAGE,
 } from '../../services/error-handler';
 import { logger } from '../../services/logger';
-import { UniswapConfig } from './uniswap.config';
+import { DefiraConfig } from './defira.config';
 import { Contract, ContractInterface } from '@ethersproject/contracts';
 import { Token, CurrencyAmount, TradeType } from '@uniswap/sdk-core';
 import * as uniV3 from '@uniswap/v3-sdk';
 import { BigNumber, Transaction, Wallet, utils } from 'ethers';
 import { ExpectedTrade, Uniswapish } from '../../services/common-interfaces';
-import { UniswapV3Helper } from './uniswap.v3.helper';
+import { DefiraV3Helper } from './defira.v3.helper';
 
 const MaxUint128 = BigNumber.from(2).pow(128).sub(1);
 
@@ -27,8 +28,8 @@ export type Overrides = {
 type SellTrade = uniV3.Trade<Token, Token, TradeType.EXACT_INPUT>;
 type BuyTrade = uniV3.Trade<Token, Token, TradeType.EXACT_OUTPUT>;
 
-export class UniswapV3 extends UniswapV3Helper implements Uniswapish {
-  private static _instances: { [name: string]: UniswapV3 };
+export class DefiraV3 extends DefiraV3Helper implements Uniswapish {
+  private static _instances: { [name: string]: DefiraV3 };
   private _chain: string;
   private _gasLimit: number;
   private _ready: boolean = false;
@@ -36,18 +37,18 @@ export class UniswapV3 extends UniswapV3Helper implements Uniswapish {
   private constructor(chain: string, network: string) {
     super(network);
     this._chain = chain;
-    this._gasLimit = UniswapConfig.config.gasLimit(3);
+    this._gasLimit = DefiraConfig.config.gasLimit(3);
   }
 
-  public static getInstance(chain: string, network: string): UniswapV3 {
-    if (UniswapV3._instances === undefined) {
-      UniswapV3._instances = {};
+  public static getInstance(chain: string, network: string): DefiraV3 {
+    if (DefiraV3._instances === undefined) {
+      DefiraV3._instances = {};
     }
-    if (!(chain + network in UniswapV3._instances)) {
-      UniswapV3._instances[chain + network] = new UniswapV3(chain, network);
+    if (!(chain + network in DefiraV3._instances)) {
+      DefiraV3._instances[chain + network] = new DefiraV3(chain, network);
     }
 
-    return UniswapV3._instances[chain + network];
+    return DefiraV3._instances[chain + network];
   }
 
   public async init() {
@@ -152,7 +153,7 @@ export class UniswapV3 extends UniswapV3Helper implements Uniswapish {
    * @param wallet Wallet
    * @param trade Expected trade
    * @param gasPrice Base gas price, for pre-EIP1559 transactions
-   * @param uniswapRouter Router smart contract address
+   * @param defiraRouter Router smart contract address
    * @param ttl How long the swap is valid before expiry, in seconds
    * @param abi Router contract ABI
    * @param gasLimit Gas limit
@@ -164,7 +165,7 @@ export class UniswapV3 extends UniswapV3Helper implements Uniswapish {
     wallet: Wallet,
     trade: uniV3.Trade<Token, Token, TradeType>,
     gasPrice: number,
-    uniswapRouter: string,
+    defiraRouter: string,
     ttl: number,
     abi: ContractInterface,
     gasLimit: number,
@@ -177,7 +178,7 @@ export class UniswapV3 extends UniswapV3Helper implements Uniswapish {
       recipient: wallet.address,
       slippageTolerance: this.getSlippagePercentage(),
     });
-    const contract: Contract = new Contract(uniswapRouter, abi, wallet);
+    const contract: Contract = new Contract(defiraRouter, abi, wallet);
 
     const tx: Transaction = await contract.multicall(
       [calldata],

--- a/gateway/src/connectors/defira/defira_v2_router_abi.json
+++ b/gateway/src/connectors/defira/defira_v2_router_abi.json
@@ -1,0 +1,985 @@
+{
+  "abi": [
+    {
+        "inputs": [
+            {
+                "type": "address",
+                "name": "_factory",
+                "internalType": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_WETH",
+                "type": "address"
+            }
+        ],
+        "type": "constructor",
+        "stateMutability": "nonpayable"
+    },
+    {
+        "name": "WETH",
+        "type": "function",
+        "inputs": [],
+        "outputs": [
+            {
+                "internalType": "address",
+                "type": "address",
+                "name": ""
+            }
+        ],
+        "stateMutability": "view"
+    },
+    {
+        "stateMutability": "view",
+        "name": "factory",
+        "type": "function",
+        "inputs": [],
+        "outputs": [
+            {
+                "name": "",
+                "type": "address",
+                "internalType": "address"
+            }
+        ]
+    },
+    {
+        "stateMutability": "payable",
+        "type": "receive"
+    },
+    {
+        "name": "addLiquidity",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "outputs": [
+            {
+                "name": "amountA",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amountB",
+                "type": "uint256"
+            },
+            {
+                "name": "liquidity",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "inputs": [
+            {
+                "name": "tokenA",
+                "internalType": "address",
+                "type": "address"
+            },
+            {
+                "name": "tokenB",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountADesired"
+            },
+            {
+                "type": "uint256",
+                "name": "amountBDesired",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amountAMin",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amountBMin",
+                "type": "uint256"
+            },
+            {
+                "name": "to",
+                "internalType": "address",
+                "type": "address"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "outputs": [
+            {
+                "type": "uint256",
+                "name": "amountToken",
+                "internalType": "uint256"
+            },
+            {
+                "name": "amountETH",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "name": "liquidity",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "type": "function",
+        "name": "addLiquidityETH",
+        "inputs": [
+            {
+                "type": "address",
+                "name": "token",
+                "internalType": "address"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "amountTokenDesired"
+            },
+            {
+                "name": "amountTokenMin",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountETHMin"
+            },
+            {
+                "type": "address",
+                "internalType": "address",
+                "name": "to"
+            },
+            {
+                "type": "uint256",
+                "name": "deadline",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "payable"
+    },
+    {
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {
+                "name": "tokenA",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "tokenB",
+                "type": "address"
+            },
+            {
+                "name": "liquidity",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "type": "uint256",
+                "name": "amountAMin",
+                "internalType": "uint256"
+            },
+            {
+                "name": "amountBMin",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "name": "to",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "type": "uint256",
+                "name": "deadline",
+                "internalType": "uint256"
+            }
+        ],
+        "name": "removeLiquidity",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountA",
+                "type": "uint256"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "amountB"
+            }
+        ]
+    },
+    {
+        "stateMutability": "nonpayable",
+        "outputs": [
+            {
+                "name": "amountToken",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "amountETH",
+                "type": "uint256"
+            }
+        ],
+        "name": "removeLiquidityETH",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "liquidity",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "amountTokenMin",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "amountETHMin"
+            },
+            {
+                "type": "address",
+                "internalType": "address",
+                "name": "to"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "type": "function"
+    },
+    {
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "amountA",
+                "type": "uint256"
+            },
+            {
+                "name": "amountB",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "tokenA",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "tokenB",
+                "type": "address"
+            },
+            {
+                "name": "liquidity",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "amountAMin"
+            },
+            {
+                "type": "uint256",
+                "name": "amountBMin",
+                "internalType": "uint256"
+            },
+            {
+                "type": "address",
+                "name": "to",
+                "internalType": "address"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "bool",
+                "name": "approveMax",
+                "type": "bool"
+            },
+            {
+                "name": "v",
+                "internalType": "uint8",
+                "type": "uint8"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "r",
+                "type": "bytes32"
+            },
+            {
+                "name": "s",
+                "internalType": "bytes32",
+                "type": "bytes32"
+            }
+        ],
+        "name": "removeLiquidityWithPermit"
+    },
+    {
+        "name": "removeLiquidityETHWithPermit",
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "token",
+                "type": "address"
+            },
+            {
+                "name": "liquidity",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "name": "amountTokenMin",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "name": "amountETHMin",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "type": "address",
+                "name": "to",
+                "internalType": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            },
+            {
+                "internalType": "bool",
+                "name": "approveMax",
+                "type": "bool"
+            },
+            {
+                "internalType": "uint8",
+                "name": "v",
+                "type": "uint8"
+            },
+            {
+                "name": "r",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "s",
+                "type": "bytes32"
+            }
+        ],
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountToken"
+            },
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountETH"
+            }
+        ]
+    },
+    {
+        "name": "removeLiquidityETHSupportingFeeOnTransferTokens",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {
+                "name": "token",
+                "internalType": "address",
+                "type": "address"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "liquidity"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "amountTokenMin"
+            },
+            {
+                "name": "amountETHMin",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "deadline"
+            }
+        ],
+        "type": "function",
+        "outputs": [
+            {
+                "type": "uint256",
+                "name": "amountETH",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "name": "removeLiquidityETHWithPermitSupportingFeeOnTransferTokens",
+        "type": "function",
+        "stateMutability": "nonpayable",
+        "inputs": [
+            {
+                "name": "token",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "name": "liquidity",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "amountTokenMin",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountETHMin"
+            },
+            {
+                "type": "address",
+                "internalType": "address",
+                "name": "to"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            },
+            {
+                "type": "bool",
+                "name": "approveMax",
+                "internalType": "bool"
+            },
+            {
+                "name": "v",
+                "type": "uint8",
+                "internalType": "uint8"
+            },
+            {
+                "type": "bytes32",
+                "name": "r",
+                "internalType": "bytes32"
+            },
+            {
+                "name": "s",
+                "type": "bytes32",
+                "internalType": "bytes32"
+            }
+        ],
+        "outputs": [
+            {
+                "type": "uint256",
+                "name": "amountETH",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "type": "function",
+        "inputs": [
+            {
+                "name": "amountIn",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "amountOutMin",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "address[]",
+                "name": "path",
+                "type": "address[]"
+            },
+            {
+                "type": "address",
+                "name": "to",
+                "internalType": "address"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "name": "swapExactTokensForTokens",
+        "stateMutability": "nonpayable",
+        "outputs": [
+            {
+                "name": "amounts",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            }
+        ]
+    },
+    {
+        "type": "function",
+        "outputs": [
+            {
+                "name": "amounts",
+                "internalType": "uint256[]",
+                "type": "uint256[]"
+            }
+        ],
+        "inputs": [
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "amountOut"
+            },
+            {
+                "name": "amountInMax",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "internalType": "address[]",
+                "name": "path",
+                "type": "address[]"
+            },
+            {
+                "name": "to",
+                "internalType": "address",
+                "type": "address"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "name": "swapTokensForExactTokens"
+    },
+    {
+        "inputs": [
+            {
+                "name": "amountOutMin",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "path",
+                "type": "address[]",
+                "internalType": "address[]"
+            },
+            {
+                "name": "to",
+                "internalType": "address",
+                "type": "address"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "deadline"
+            }
+        ],
+        "outputs": [
+            {
+                "name": "amounts",
+                "internalType": "uint256[]",
+                "type": "uint256[]"
+            }
+        ],
+        "stateMutability": "payable",
+        "name": "swapExactETHForTokens",
+        "type": "function"
+    },
+    {
+        "stateMutability": "nonpayable",
+        "type": "function",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "swapTokensForExactETH",
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountOut"
+            },
+            {
+                "name": "amountInMax",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "address[]",
+                "type": "address[]",
+                "name": "path"
+            },
+            {
+                "type": "address",
+                "name": "to",
+                "internalType": "address"
+            },
+            {
+                "type": "uint256",
+                "name": "deadline",
+                "internalType": "uint256"
+            }
+        ]
+    },
+    {
+        "outputs": [
+            {
+                "name": "amounts",
+                "type": "uint256[]",
+                "internalType": "uint256[]"
+            }
+        ],
+        "inputs": [
+            {
+                "name": "amountIn",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountOutMin"
+            },
+            {
+                "type": "address[]",
+                "name": "path",
+                "internalType": "address[]"
+            },
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "name": "deadline",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "name": "swapExactTokensForETH",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "name": "amountOut",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "type": "address[]",
+                "internalType": "address[]",
+                "name": "path"
+            },
+            {
+                "name": "to",
+                "type": "address",
+                "internalType": "address"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "deadline"
+            }
+        ],
+        "stateMutability": "payable",
+        "name": "swapETHForExactTokens",
+        "type": "function",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "type": "uint256[]",
+                "name": "amounts"
+            }
+        ]
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountIn"
+            },
+            {
+                "name": "amountOutMin",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "type": "address[]",
+                "name": "path",
+                "internalType": "address[]"
+            },
+            {
+                "name": "to",
+                "internalType": "address",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "deadline",
+                "type": "uint256"
+            }
+        ],
+        "outputs": [],
+        "type": "function",
+        "name": "swapExactTokensForTokensSupportingFeeOnTransferTokens",
+        "stateMutability": "nonpayable"
+    },
+    {
+        "stateMutability": "payable",
+        "type": "function",
+        "name": "swapExactETHForTokensSupportingFeeOnTransferTokens",
+        "outputs": [],
+        "inputs": [
+            {
+                "name": "amountOutMin",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "type": "address[]",
+                "name": "path",
+                "internalType": "address[]"
+            },
+            {
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            },
+            {
+                "name": "deadline",
+                "internalType": "uint256",
+                "type": "uint256"
+            }
+        ]
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "amountIn"
+            },
+            {
+                "name": "amountOutMin",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "name": "path",
+                "internalType": "address[]",
+                "type": "address[]"
+            },
+            {
+                "name": "to",
+                "internalType": "address",
+                "type": "address"
+            },
+            {
+                "type": "uint256",
+                "name": "deadline",
+                "internalType": "uint256"
+            }
+        ],
+        "type": "function",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "name": "swapExactTokensForETHSupportingFeeOnTransferTokens"
+    },
+    {
+        "name": "quote",
+        "inputs": [
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "amountA"
+            },
+            {
+                "name": "reserveA",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "type": "uint256",
+                "name": "reserveB"
+            }
+        ],
+        "outputs": [
+            {
+                "type": "uint256",
+                "name": "amountB",
+                "internalType": "uint256"
+            }
+        ],
+        "stateMutability": "pure",
+        "type": "function"
+    },
+    {
+        "name": "getAmountOut",
+        "outputs": [
+            {
+                "name": "amountOut",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "type": "function",
+        "inputs": [
+            {
+                "name": "amountIn",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "reserveIn"
+            },
+            {
+                "type": "uint256",
+                "internalType": "uint256",
+                "name": "reserveOut"
+            },
+            {
+                "name": "swapFee",
+                "internalType": "uint256",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "pure"
+    },
+    {
+        "inputs": [
+            {
+                "name": "amountOut",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "reserveIn",
+                "type": "uint256"
+            },
+            {
+                "type": "uint256",
+                "name": "reserveOut",
+                "internalType": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "swapFee",
+                "type": "uint256"
+            }
+        ],
+        "name": "getAmountIn",
+        "outputs": [
+            {
+                "name": "amountIn",
+                "type": "uint256",
+                "internalType": "uint256"
+            }
+        ],
+        "type": "function",
+        "stateMutability": "pure"
+    },
+    {
+        "type": "function",
+        "outputs": [
+            {
+                "type": "uint256[]",
+                "name": "amounts",
+                "internalType": "uint256[]"
+            }
+        ],
+        "inputs": [
+            {
+                "name": "amountIn",
+                "internalType": "uint256",
+                "type": "uint256"
+            },
+            {
+                "type": "address[]",
+                "internalType": "address[]",
+                "name": "path"
+            }
+        ],
+        "name": "getAmountsOut",
+        "stateMutability": "view"
+    },
+    {
+        "inputs": [
+            {
+                "name": "amountOut",
+                "type": "uint256",
+                "internalType": "uint256"
+            },
+            {
+                "name": "path",
+                "type": "address[]",
+                "internalType": "address[]"
+            }
+        ],
+        "stateMutability": "view",
+        "outputs": [
+            {
+                "internalType": "uint256[]",
+                "name": "amounts",
+                "type": "uint256[]"
+            }
+        ],
+        "name": "getAmountsIn",
+        "type": "function"
+    }
+  ]
+}


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Add a Defira connector gateway connector scaffold. This is a copy-paste of the Uniswap gateway connector with a fairly
minimal set of renamings from uniswap -> defira where it definitely makes sense. I'm still declaring things like 
"uniswap router" instead of "defira router" for now since "Defira V3" etc doesn't make that much sense since Defira is
not exactly versioned that way.

* Switch from using Ethereum blockchain to Harmony blockchain in the main gateway connector file
* Add pretty-printed Defira exchange ABI from Harmony blockchain explorer

**Tests performed by the developer**:

None. Just a scaffold.

**Tips for QA testing**:

N/A

