### PR TITLE
Add testnet tokens JSON, tranquil -> defira

### DIFF
--- a/gateway/src/chains/harmony/harmony_tokens_defira.json
+++ b/gateway/src/chains/harmony/harmony_tokens_defira.json
@@ -1,5 +1,5 @@
 {
-  "name": "Tranquil Finance Token List",
+  "name": "Defira Token List",
   "logoURI": "https://sushi.com/static/media/logo.dec926df.png",
   "version": {
     "major": 0,

--- a/gateway/src/chains/harmony/harmony_tokens_defira_testnet.json
+++ b/gateway/src/chains/harmony/harmony_tokens_defira_testnet.json
@@ -1,0 +1,29 @@
+{
+  "name": "Defira Token List",
+  "logoURI": "https://sushi.com/static/media/logo.dec926df.png",
+  "version": {
+    "major": 0,
+    "minor": 1,
+    "patch": 1
+  },
+  "keywords": [],
+  "timestamp": "2022-01-30T00:00:00+00:00",
+  "tokens": [
+    {
+      "name": "Wrapped ONE",
+      "address": "0x7466d7d0C21Fa05F32F5a0Fa27e12bdC06348Ce2",
+      "symbol": "WONE",
+      "decimals": 18,
+      "chainId": 1666700000,
+      "logoURI": "https://raw.githubusercontent.com/sushiswap/icons/master/token/one.jpg"
+    },
+    {
+      "name": "OneETH",
+      "address": "0x1E120B3b4aF96e7F394ECAF84375b1C661830013",
+      "symbol": "1ETH",
+      "decimals": 18,
+      "chainId": 1666700000,
+      "logoURI": "https://assets.coingecko.com/coins/images/279/small/ethereum.png"
+    }
+  ]
+}


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Add just a couple testnet tokens for Defira for now. Rename Tranquil to Defira in token JSON file names to avoid confusion.

**Tests performed by the developer**:

Getting the price between testnet WONE and 1ETH works 🎉 

```
$ http POST http://localhost:5000/amm/price --raw '{"quote": "1ETH", "base": "WONE", "amount": "1", "side": "SELL", "chain": "harmony", "network": "testnet", "connector": "defira"}'
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 399
Content-Type: application/json; charset=utf-8
Date: Thu, 16 Jun 2022 09:08:30 GMT
ETag: W/"18f-vPcPFUYys3+y47vpo4mDv2/0NiE"
Keep-Alive: timeout=5
X-Powered-By: Express

http POST http://localhost:5000/amm/price --raw '{"quote": "1ETH", "base": "WONE", "amount": "0.007966161332037003", "side": "BUY", "chain": "harmony", "network": "testnet", "connector": "defira"}'
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 398
Content-Type: application/json; charset=utf-8
Date: Thu, 16 Jun 2022 09:16:07 GMT
ETag: W/"18e-DYuQN1n1AKbDaEFi62/7pN7wjoI"
Keep-Alive: timeout=5
X-Powered-By: Express

{
    "amount": "0.007966161332037003",
    "base": "0x7466d7d0C21Fa05F32F5a0Fa27e12bdC06348Ce2",
    "expectedAmount": "0.00000000041949348",
    "gasCost": "452064.000000000000000000",
    "gasLimit": 150688,
    "gasPrice": 3000000000,
    "gasPriceToken": "ONE",
    "latency": 0.514,
    "network": "testnet",
    "price": "0.000000051626889",
    "quote": "0x1E120B3b4aF96e7F394ECAF84375b1C661830013",
    "rawAmount": "7966161332037003",
    "timestamp": 1655370967122
}
```

**Tips for QA testing**:

Keep testing other AMM endpoints.

