### PR TITLE
Fix automatic gas calculation

### DIFF
--- a/gateway/src/chains/harmony/harmony.ts
+++ b/gateway/src/chains/harmony/harmony.ts
@@ -122,8 +122,8 @@ export class Harmony extends EthereumBase implements Ethereumish {
 
       const { data } = await axios(config);
 
-      // divide by 10 to convert it to Gwei
-      this._gasPrice = data['result'] / 10;
+      // divide by 1e9 to convert it to Gwei
+      this._gasPrice = data['result'] / 1e9;
       this._gasPriceLastUpdated = new Date();
 
       setTimeout(
@@ -138,13 +138,14 @@ export class Harmony extends EthereumBase implements Ethereumish {
   }
 
   getSpender(reqSpender: string): string {
-    // TODO: add SushiswapConfig and ViperswapConfig
+    // TODO: add SushiswapConfig and ViperswapConfig and Defira configs (or move `approve` to AMM)
     let spender: string;
     if (reqSpender === 'sushiswap') {
       spender = '0x1b02da8cb0d097eb8d57a175b88c7d8b47997506';
-    }
-    if (reqSpender === 'viperswap') {
+    } else if (reqSpender === 'viperswap') {
       spender = '0xf012702a5f0e54015362cbca26a26fc90aa832a3';
+    } else if (reqSpender === 'defira') {
+      spender = '0x3C8BF7e25EbfAaFb863256A4380A8a93490d8065';
     } else {
       spender = reqSpender;
     }


### PR DESCRIPTION
**A description of the changes proposed in the pull request**:

Harmony automatic gas pricing seems to be wrong.  The testnet RPC is returning 3e10, but the code suggests dividing
by 10 gives the gas price in Gwei. That seems to not be the case, since 3e9 Gwei would be an insanely high value. Divide
by 1e9 instead.

**Tests performed by the developer**:

Testnet trade succeeds if and only if I apply this PR.

```
http POST http://localhost:5000/amm/trade --raw '{"quote": "1ETH", "base": "WONE", "amount": "0.1", "side": "SELL", "chain": "harmony", "network": "testnet", "connector": "defira", "limitPrice": "0.00000003", "address": "0xb8124bF4777d63c54f2879f6674E3C31Bb6fc1C9"}'
HTTP/1.1 200 OK
Connection: keep-alive
Content-Length: 472
Content-Type: application/json; charset=utf-8
Date: Fri, 17 Jun 2022 06:01:04 GMT
ETag: W/"1d8-1r260+yntMRssdCA0PZunjaVJ/U"
Keep-Alive: timeout=5
X-Powered-By: Express

{
    "amount": "0.100000000000000000",
    "base": "0x7466d7d0C21Fa05F32F5a0Fa27e12bdC06348Ce2",
    "expectedOut": "0.0000000037569066",
    "gasCost": "0.004520640000000000",
    "gasLimit": 150688,
    "gasPrice": 30,
    "gasPriceToken": "ONE",
    "latency": 3.461,
    "network": "testnet",
    "nonce": 76,
    "price": "0.000000038320448",
    "quote": "0x1E120B3b4aF96e7F394ECAF84375b1C661830013",
    "rawAmount": "100000000000000000",
    "timestamp": 1655445661492,
    "txHash": "0xaf24a56bc335d4e5a9396824a43007d00103eb8a9514f502c79d9bee1bb20bce"
}
```

**Tips for QA testing**:

Look at the actual gas price submitted to the Ethers contract when using automatic gas pricing. You'll find it's much too
high.